### PR TITLE
feat: make client take headers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ export interface MockDataConfig {
 
 export interface LoadTestConfig {
   serverUrl: string
+  headers?: Record<string, string> // headers for when we connect to serverUrl 
   numCalls?: number
   delayBetweenCalls?: number
   toolNames?: string[]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "benchmark-mcp",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Load test a Model Context Protocol server with random or scripted tools and parameters",
   "main": "src/index.js",
   "type": "module",

--- a/src/index.js
+++ b/src/index.js
@@ -73,7 +73,12 @@ class MCPClient {
     this.tools = []
     this.faker = fakerInstance
     this.sequenceContext = {}
-    this.transport = new StreamableHTTPClientTransport(new URL(serverUrl))
+    
+    const transportOpts = {}
+    if (config.headers) {
+      transportOpts.requestInit = { headers: config.headers }
+    }
+    this.transport = new StreamableHTTPClientTransport(new URL(serverUrl), transportOpts)
     /** @type {LoadTestConfig} */
     this.config = config
     /** @type {import('./metrics.js').Metrics} */


### PR DESCRIPTION
making the client take headers so we can do x-forwarded-host
(look at this https://github.com/readmeio/ai/pull/190, in the integration test)